### PR TITLE
Set up code quality and testing validation

### DIFF
--- a/actions/pylint-validation/action.yml
+++ b/actions/pylint-validation/action.yml
@@ -27,13 +27,28 @@ runs:
       shell: bash
       run: |
         set -e
+
+        # Build ignore-paths from ignore input (convert comma-separated to regex)
         if [ -n "${{ inputs.ignore }}" ]; then
-          ignore="--ignore ${{ inputs.ignore }}"
+          IFS=',' read -ra paths <<< "${{ inputs.ignore }}"
+          ignore_paths_list=""
+          for path in "${paths[@]}"; do
+            path=$(echo "$path" | xargs)  # Trim whitespace
+            if [ -n "$ignore_paths_list" ]; then
+              ignore_paths_list+=","
+            fi
+            ignore_paths_list+=".*${path}.*"
+          done
+          ignore="--ignore-paths=$ignore_paths_list"
         fi
+
+        # Use ignore-patterns if provided
         if [ -n "${{ inputs.ignore-patterns }}" ]; then
           ignore_patterns="--ignore-patterns=${{ inputs.ignore-patterns }}"
         fi
+
         if [ -n "${{ inputs.enable }}" ]; then
           enable="--disable=all --enable=${{ inputs.enable }}"
         fi
+
         pylint ${{ inputs.root-dir }} $ignore $ignore_patterns $enable ${{ inputs.extra-args }} | mk_pylint_report

--- a/actions/pytest-validation/action.yml
+++ b/actions/pytest-validation/action.yml
@@ -62,16 +62,29 @@ runs:
           done
         fi
 
+        # Build pytest --ignore flags from paths-to-ignore
+        pytest_ignore_flags=""
+        if [ -n "${{ inputs.paths-to-ignore }}" ]; then
+          IFS=',' read -ra ignore_paths <<< "${{ inputs.paths-to-ignore }}"
+          for ignore_path in "${ignore_paths[@]}"; do
+            ignore_path=$(echo "$ignore_path" | xargs)  # Trim whitespace
+            if [ -n "$ignore_path" ]; then
+              pytest_ignore_flags+=" --ignore=${{ inputs.root-dir }}/$ignore_path"
+            fi
+          done
+        fi
+
         # Prepare test targets
         if [ "${{ inputs.skip-doctests }}" = "true" ]; then
-          echo "Running: pytest $options ${{ inputs.root-dir }}"
-          pytest $options "${{ inputs.root-dir }}"
+          echo "Running: pytest $options $pytest_ignore_flags ${{ inputs.root-dir }}"
+          # shellcheck disable=SC2086
+          pytest $options $pytest_ignore_flags "${{ inputs.root-dir }}"
         else
           # Safely evaluate find command with dynamic ignore_expr
           echo "Finding .py files excluding: ${{ inputs.paths-to-ignore }}"
           # shellcheck disable=SC2086
           files=$(eval "find '${{ inputs.root-dir }}' -type f -name '*.py' $ignore_expr")
-          
+
           echo "Running: pytest $options --doctest-modules $files"
           # shellcheck disable=SC2086
           pytest $options --doctest-modules -o doctest_optionflags="ELLIPSIS IGNORE_EXCEPTION_DETAIL" $files


### PR DESCRIPTION
This fixes the ignore path functionality that stopped working with newer versions of pylint and pytest.

Changes:
- pylint-validation: Changed from --ignore to --ignore-paths with regex patterns, as --ignore no longer works correctly in pylint 4.x
- pytest-validation: Added --ignore flag support when skip-doctests is enabled, so paths-to-ignore is respected in both modes

Fixes #32