### PR TITLE
Make install-requires/tests-require pyproject.toml-aware (closes #38)

### DIFF
--- a/actions/install-packages/action.yml
+++ b/actions/install-packages/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: 'NPM packages to install'
     required: false
   dependency-files:
-    description: 'Paths to dependency files. Can be a requirements.txt or a setup.cfg file'
+    description: 'Paths to dependency files. Can be a requirements.txt, a pyproject.toml, or a setup.cfg file'
     required: false
   test-requirements-file:
     description: "Paths to requirements files. Provide a comma separated list of paths from the current directory. '.txt' files will be pip installed. '.cfg' files will be parsed and the install_requires and tests_require sections will be installed."
@@ -95,7 +95,7 @@ runs:
             echo "Installing requirements from $path"
             python -m pip install -r $path
             echo "Completed installing requirements from $path"
-          elif [[ $path == *.cfg ]]; then
+          elif [[ $path == *.cfg || $path == *.toml ]]; then
             if [ "$isee_installed" == "false" ]; then
               if [ "${{ github.repository }}" == "i2mint/isee" ]; then
                 echo "Installing isee from source"

--- a/isee/pip_utils.py
+++ b/isee/pip_utils.py
@@ -1,22 +1,207 @@
 """
-This module provides utilities for working with pip and setup.cfg files.
+Utilities for reading a project's declared dependencies and installing them.
+
+These functions back the ``isee install-requires`` and ``isee tests-require``
+CLI commands (and therefore the ``install-packages`` action). They understand
+both modern ``pyproject.toml`` (PEP 621 ``[project]``) and legacy ``setup.cfg``
+projects, preferring ``pyproject.toml`` whenever it declares a ``[project]``
+table.
 
 Functions:
-- read_setup_config: Read the setup.cfg file in the project directory.
-- install_packages_from_options: Install packages from the options in setup.cfg.
-- install_requires: Install packages from the install_requires option in setup.cfg.
-- tests_require: Install packages from the tests_require option in setup.cfg.
+- install_requires: Install the project's runtime dependencies.
+- tests_require: Install the project's test dependencies.
+- resolve_install_requires: Resolve (without installing) the runtime deps.
+- resolve_tests_require: Resolve (without installing) the test deps.
+- read_setup_config: (legacy) Read the setup.cfg file in the project directory.
 - build_dependency_wheels: Build dependency wheels for the project.
+- extras_require / install_extras: (legacy) setup.cfg extras_require helpers.
 
 """
 
 import configparser
+import os
 import pip
+
+try:  # Python 3.11+
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10 (pyproject declares tomli as fallback)
+    import tomli as tomllib
 
 from isee.common import get_env_var, get_file_path
 
+# Extras (in priority order) treated as the project's "test" dependencies when
+# reading [project.optional-dependencies] from a pyproject.toml. The first one
+# present wins. Override via the ``test_extras`` argument of tests_require.
+DFLT_TEST_EXTRAS = ("testing", "test", "tests", "dev")
+
+
+# --------------------------------------------------------------------------- #
+# Metadata source resolution (pyproject.toml preferred, setup.cfg fallback)
+# --------------------------------------------------------------------------- #
+
+
+def _resolve_project_dir(project_dir=None):
+    return project_dir or get_env_var("GITHUB_WORKSPACE")
+
+
+def _find_file(filename, project_dir):
+    """Return the path to ``filename`` within ``project_dir``.
+
+    The project root is preferred; failing that we fall back to a recursive
+    search (matching the legacy ``get_file_path`` behaviour). Returns ``None``
+    when no such file is found.
+    """
+    root_candidate = os.path.join(project_dir, filename)
+    if os.path.isfile(root_candidate):
+        return root_candidate
+    try:
+        return get_file_path(filename, project_dir)
+    except RuntimeError:
+        return None
+
+
+def _load_toml(path):
+    with open(path, "rb") as f:
+        return tomllib.load(f)
+
+
+def _metadata_source(project_dir):
+    """Detect the project's dependency-metadata source.
+
+    Returns one of:
+    - ``("pyproject", data)`` when a ``pyproject.toml`` with a ``[project]``
+      table is present (``data`` is the parsed toml dict),
+    - ``("setup_cfg", config)`` when only a ``setup.cfg`` is present
+      (``config`` is a parsed ``ConfigParser``),
+    - ``(None, None)`` when neither is found.
+    """
+    pyproject_path = _find_file("pyproject.toml", project_dir)
+    if pyproject_path:
+        data = _load_toml(pyproject_path)
+        if "project" in data:
+            return "pyproject", data
+    setup_cfg_path = _find_file("setup.cfg", project_dir)
+    if setup_cfg_path:
+        config = configparser.ConfigParser()
+        config.read(setup_cfg_path)
+        return "setup_cfg", config
+    return None, None
+
+
+def _no_metadata_error(project_dir):
+    return RuntimeError(
+        f'No dependency metadata found in "{project_dir}": expected a '
+        f"pyproject.toml with a [project] table or a setup.cfg with an "
+        f"[options] section. If this project genuinely declares no "
+        f"dependencies, drop the dependency-files step from your CI."
+    )
+
+
+def _cfg_option_list(config, section, key):
+    """Return the newline-separated list under ``config[section][key]``."""
+    if section not in config:
+        return []
+    raw = config[section].get(key)
+    if not raw:
+        return []
+    return [line.strip() for line in raw.splitlines() if line.strip()]
+
+
+def _pyproject_test_deps(data, test_extras):
+    optional = data.get("project", {}).get("optional-dependencies", {})
+    for name in test_extras:
+        if name in optional:
+            return list(optional[name])
+    return []
+
+
+# --------------------------------------------------------------------------- #
+# Public resolvers (no side effects) and installers
+# --------------------------------------------------------------------------- #
+
+
+def resolve_install_requires(*, project_dir=None):
+    """Return the project's runtime dependencies as a list of requirement strings.
+
+    Reads ``[project].dependencies`` from ``pyproject.toml`` when present,
+    otherwise ``[options] install_requires`` from ``setup.cfg``. Raises a
+    ``RuntimeError`` only when neither metadata file exists.
+    """
+    project_dir = _resolve_project_dir(project_dir)
+    source, meta = _metadata_source(project_dir)
+    if source == "pyproject":
+        return list(meta.get("project", {}).get("dependencies", []))
+    if source == "setup_cfg":
+        return _cfg_option_list(meta, "options", "install_requires")
+    raise _no_metadata_error(project_dir)
+
+
+def resolve_tests_require(*, project_dir=None, test_extras=DFLT_TEST_EXTRAS):
+    """Return the project's test dependencies as a list of requirement strings.
+
+    Reads ``[project.optional-dependencies]`` from ``pyproject.toml`` (the first
+    of ``test_extras`` that is present) when a ``[project]`` table exists,
+    otherwise ``[options] tests_require`` from ``setup.cfg``. Raises a
+    ``RuntimeError`` only when neither metadata file exists.
+    """
+    project_dir = _resolve_project_dir(project_dir)
+    source, meta = _metadata_source(project_dir)
+    if source == "pyproject":
+        return _pyproject_test_deps(meta, test_extras)
+    if source == "setup_cfg":
+        return _cfg_option_list(meta, "options", "tests_require")
+    raise _no_metadata_error(project_dir)
+
+
+def _pip_install(pkgs, *, label):
+    pkgs = [p for p in pkgs if p]
+    if pkgs:
+        pip.main(["install"] + pkgs)
+    else:
+        print(f"No {label} packages to install")
+
+
+def install_requires(*, project_dir=None):
+    """Install the project's runtime dependencies.
+
+    Reads them from ``pyproject.toml`` ``[project].dependencies`` when present,
+    otherwise ``setup.cfg`` ``[options] install_requires``.
+    """
+    _pip_install(resolve_install_requires(project_dir=project_dir), label="install_requires")
+
+
+def tests_require(*, project_dir=None, test_extras=DFLT_TEST_EXTRAS):
+    """Install the project's test dependencies.
+
+    Reads them from ``pyproject.toml`` ``[project.optional-dependencies]`` (the
+    first present of ``test_extras``) when present, otherwise ``setup.cfg``
+    ``[options] tests_require``.
+    """
+    _pip_install(
+        resolve_tests_require(project_dir=project_dir, test_extras=test_extras),
+        label="tests_require",
+    )
+
+
+def build_dependency_wheels(repository_dir, wheelhouse, requirements_filepath=None):
+    args = ["wheel", "--wheel-dir", wheelhouse, "--find-links", wheelhouse]
+    if requirements_filepath:
+        args.extend(["--requirement", requirements_filepath])
+    args.extend(["--editable", repository_dir])
+    pip.main(args)
+
+
+# --------------------------------------------------------------------------- #
+# Legacy setup.cfg helpers (kept for backward compatibility)
+# --------------------------------------------------------------------------- #
+
 
 def read_setup_config(project_dir=None):
+    """(legacy) Read and return the ``setup.cfg`` ConfigParser for the project.
+
+    Prefer :func:`resolve_install_requires` / :func:`resolve_tests_require`,
+    which also understand ``pyproject.toml``.
+    """
     if not project_dir:
         project_dir = get_env_var("GITHUB_WORKSPACE")
     path = get_file_path("setup.cfg", project_dir)
@@ -31,25 +216,6 @@ def install_packages_from_options(config_options, key):
         pip.main(["install"] + pkgs)
     else:
         print(f"No {key} packages to install")
-
-
-def install_requires(*, project_dir=None):
-    config = read_setup_config(project_dir)
-    install_packages_from_options(config["options"], "install_requires")
-
-
-def tests_require(*, project_dir=None):
-    """Install from tests_require in setup.cfg options"""
-    config = read_setup_config(project_dir)
-    install_packages_from_options(config["options"], "tests_require")
-
-
-def build_dependency_wheels(repository_dir, wheelhouse, requirements_filepath=None):
-    args = ["wheel", "--wheel-dir", wheelhouse, "--find-links", wheelhouse]
-    if requirements_filepath:
-        args.extend(["--requirement", requirements_filepath])
-    args.extend(["--editable", repository_dir])
-    pip.main(args)
 
 
 def extras_require(name="testing", *, project_dir=None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 keywords = []
 authors = []
-dependencies = ["semver==2.13.0", "wads"]
+dependencies = ["semver==2.13.0", "wads", "tomli; python_version < '3.11'"]
 
 [project.license]
 text = "MIT"

--- a/tests/test_pip_utils.py
+++ b/tests/test_pip_utils.py
@@ -1,0 +1,117 @@
+"""Tests for pip_utils dependency resolution across pyproject.toml and setup.cfg.
+
+These tests exercise the (side-effect-free) resolver functions so they never
+touch pip. They cover the issue #38 scenario: a pyproject.toml-only project
+must resolve its dependencies instead of raising "No file with name setup.cfg".
+"""
+
+from textwrap import dedent
+
+import pytest
+
+from isee.pip_utils import (
+    resolve_install_requires,
+    resolve_tests_require,
+)
+
+PYPROJECT = dedent(
+    """
+    [build-system]
+    requires = ["hatchling"]
+
+    [project]
+    name = "demo"
+    version = "0.0.1"
+    dependencies = ["requests>=2", "rich"]
+
+    [project.optional-dependencies]
+    testing = ["pytest", "coverage"]
+    docs = ["sphinx"]
+    """
+)
+
+SETUP_CFG = dedent(
+    """
+    [options]
+    install_requires =
+        requests>=2
+        rich
+    tests_require =
+        pytest
+        coverage
+    """
+)
+
+
+def _write(tmp_path, name, content):
+    (tmp_path / name).write_text(content)
+
+
+class TestPyproject:
+    def test_install_requires(self, tmp_path):
+        _write(tmp_path, "pyproject.toml", PYPROJECT)
+        assert resolve_install_requires(project_dir=str(tmp_path)) == [
+            "requests>=2",
+            "rich",
+        ]
+
+    def test_tests_require_default_testing_extra(self, tmp_path):
+        _write(tmp_path, "pyproject.toml", PYPROJECT)
+        assert resolve_tests_require(project_dir=str(tmp_path)) == [
+            "pytest",
+            "coverage",
+        ]
+
+    def test_tests_require_custom_extra(self, tmp_path):
+        _write(tmp_path, "pyproject.toml", PYPROJECT)
+        assert resolve_tests_require(
+            project_dir=str(tmp_path), test_extras=("docs",)
+        ) == ["sphinx"]
+
+    def test_no_dependencies_is_empty_not_error(self, tmp_path):
+        _write(
+            tmp_path,
+            "pyproject.toml",
+            "[project]\nname = 'demo'\nversion = '0.0.1'\n",
+        )
+        assert resolve_install_requires(project_dir=str(tmp_path)) == []
+        assert resolve_tests_require(project_dir=str(tmp_path)) == []
+
+    def test_pyproject_preferred_over_setup_cfg(self, tmp_path):
+        _write(tmp_path, "pyproject.toml", PYPROJECT)
+        _write(tmp_path, "setup.cfg", "[options]\ninstall_requires =\n    legacy-pkg\n")
+        # pyproject wins
+        assert "legacy-pkg" not in resolve_install_requires(project_dir=str(tmp_path))
+
+
+class TestSetupCfg:
+    def test_install_requires(self, tmp_path):
+        _write(tmp_path, "setup.cfg", SETUP_CFG)
+        assert resolve_install_requires(project_dir=str(tmp_path)) == [
+            "requests>=2",
+            "rich",
+        ]
+
+    def test_tests_require(self, tmp_path):
+        _write(tmp_path, "setup.cfg", SETUP_CFG)
+        assert resolve_tests_require(project_dir=str(tmp_path)) == [
+            "pytest",
+            "coverage",
+        ]
+
+    def test_pyproject_without_project_table_falls_back_to_cfg(self, tmp_path):
+        # A pyproject.toml that only carries tool config must NOT shadow setup.cfg
+        _write(tmp_path, "pyproject.toml", "[tool.ruff]\nline-length = 88\n")
+        _write(tmp_path, "setup.cfg", SETUP_CFG)
+        assert resolve_install_requires(project_dir=str(tmp_path)) == [
+            "requests>=2",
+            "rich",
+        ]
+
+
+class TestMissingMetadata:
+    def test_raises_clear_error(self, tmp_path):
+        with pytest.raises(RuntimeError, match="No dependency metadata found"):
+            resolve_install_requires(project_dir=str(tmp_path))
+        with pytest.raises(RuntimeError, match="No dependency metadata found"):
+            resolve_tests_require(project_dir=str(tmp_path))


### PR DESCRIPTION
## Summary

`isee install-requires` / `isee tests-require` — and therefore the
`install-packages` action's `dependency-files` path — only understood
`setup.cfg`, hard-failing on `pyproject.toml`-only repos with
`RuntimeError: No file with name "setup.cfg" exist ...`. This silently broke CI
for any pyproject-only repo whose `ci.yml` still passed a `.cfg`.

Fixes #38.

## What changed

- **`isee/pip_utils.py`** — new `_metadata_source()` resolver: prefer
  `pyproject.toml` when it has a `[project]` table, otherwise fall back to
  `setup.cfg`.
  - `install_requires` → `[project].dependencies` (else `[options] install_requires`).
  - `tests_require` → `[project.optional-dependencies]` (first present of
    `testing`/`test`/`tests`/`dev`, overridable via `test_extras`; else
    `[options] tests_require`).
  - Empty deps → logged no-op (`No <kind> packages to install`); only a total
    absence of metadata raises, now with an actionable message.
  - New side-effect-free `resolve_install_requires` / `resolve_tests_require`
    expose resolution without invoking pip (and back the tests).
  - Legacy `read_setup_config` / `extras_require` / `install_extras` kept.
- **`actions/install-packages/action.yml`** — the Install Dependencies step now
  triggers on `*.toml` as well as `*.cfg`; input description updated.
- **`pyproject.toml`** — `tomli` fallback dependency for Python 3.10 (`tomllib`
  is 3.11+).
- **`tests/test_pip_utils.py`** — covers pyproject resolution, custom extras,
  empty-deps no-op, pyproject-preferred-over-cfg, cfg fallback when pyproject
  carries only tool config, and the clear error when neither file exists.

## Testing

`pytest tests/test_pip_utils.py` → 9 passed. Full suite: only the 3
pre-existing `local_cli` `--bind` failures remain (unrelated to this change;
they also fail on `master`).