### PR TITLE
Modernize CI build/install to PEP 517 (prereq for removing setup.py)

### DIFF
--- a/actions/install-packages/action.yml
+++ b/actions/install-packages/action.yml
@@ -38,12 +38,10 @@ runs:
         
         if [[ "${{ inputs.pypi-packages }}" == "isee" && "${{ github.repository }}" == "i2mint/isee" ]]; then
           echo "Installing isee from source"
-          python setup.py sdist
-          python -m pip install $(ls -t dist/isee-*.tar.gz 2>/dev/null | head -n 1)
+          python -m pip install .
         elif [[ "${{ inputs.pypi-packages }}" == "wads" && "${{ github.repository }}" == "i2mint/wads" ]]; then
           echo "Installing wads from source"
-          python setup.py sdist
-          python -m pip install $(ls -t dist/wads-*.tar.gz 2>/dev/null | head -n 1)
+          python -m pip install .
         else
           echo "Installing packages: ${{ inputs.pypi-packages }}"
           python -m pip install ${{ inputs.pypi-packages }}
@@ -99,8 +97,7 @@ runs:
             if [ "$isee_installed" == "false" ]; then
               if [ "${{ github.repository }}" == "i2mint/isee" ]; then
                 echo "Installing isee from source"
-                python setup.py sdist
-                python -m pip install $(ls -t dist/isee-*.tar.gz 2>/dev/null | head -n 1)
+                python -m pip install .
               else
                 echo "Installing isee from pip"
                 pip -q install isee

--- a/actions/package/action.yml
+++ b/actions/package/action.yml
@@ -21,14 +21,29 @@ runs:
         dependency-files: setup.cfg
         ssh-private-key: ${{ inputs.ssh-private-key }}
 
-    - name: "Run setup.py"
+    - name: "Build distributions"
       shell: bash
       run: |
         set -e
-        distributions=""
-        IFS=',' read -ra paths <<< "${{ inputs.distributions }}"
-          for path in "${paths[@]}"
-          do
-              distributions+=" $path"
-          done
-        python setup.py $distributions
+        python -m pip install --upgrade build
+        # Map legacy setup.py distribution names to PEP 517 `build` flags.
+        want_sdist=false
+        want_wheel=false
+        IFS=',' read -ra dists <<< "${{ inputs.distributions }}"
+        for d in "${dists[@]}"; do
+          d="$(echo "$d" | xargs)"  # trim surrounding whitespace
+          case "$d" in
+            sdist) want_sdist=true ;;
+            bdist_wheel) want_wheel=true ;;
+            *) echo "Warning: distribution '$d' is not supported by 'python -m build'; building sdist + wheel instead" ;;
+          esac
+        done
+        build_args=""
+        if [ "$want_sdist" = "true" ] && [ "$want_wheel" = "false" ]; then
+          build_args="--sdist"
+        elif [ "$want_wheel" = "true" ] && [ "$want_sdist" = "false" ]; then
+          build_args="--wheel"
+        fi
+        # No flags => build builds both sdist and wheel (the default distributions).
+        echo "Running: python -m build $build_args"
+        python -m build $build_args

--- a/actions/publish-job/action.yml
+++ b/actions/publish-job/action.yml
@@ -71,7 +71,10 @@ runs:
       shell: bash
 
     - name: Package
-      run: python setup.py sdist
+      run: |
+        set -e
+        python -m pip install --upgrade build
+        python -m build --sdist
       shell: bash
 
     - name: Publish


### PR DESCRIPTION
PR A of two (Refs #40). Modernizes every `python setup.py sdist` site in the reusable actions to PEP 517 equivalents, so the actions no longer depend on `setup.py`. **Keeps `setup.py`** — its removal is the follow-up PR B, which must land *after* this is on `master` (CI calls these actions `@master`, so `master` must carry the modern actions before the tree can drop `setup.py`).

## Changes

- **`actions/install-packages`** — isee/wads self-install → `python -m pip install .` (both the "Install Pypi Packages" and "Install Dependencies" steps).
- **`actions/package`** — `python setup.py $distributions` → `python -m build`, mapping the legacy `sdist`/`bdist_wheel` distribution names to build's `--sdist`/`--wheel` flags (default `sdist,bdist_wheel` → builds both, as before).
- **`actions/publish-job`** — `python setup.py sdist` → `python -m build --sdist` (still emits `dist/NAME-VERSION.tar.gz` for the twine upload).

## Compatibility

Behavior-preserving and backward compatible: `pip install .` and `python -m build` work for both `pyproject.toml` and legacy `setup.cfg`-only repos (setuptools legacy backend auto-selected when there's no `[build-system]`), so other i2mint repos consuming these `@master` actions are unaffected. Verified locally that `python -m build` builds isee via hatchling (sdist + wheel).

This PR's own CI still runs the **old** `@master` action code against a tree that still has `setup.py`, so it should stay green.